### PR TITLE
Replace bcmdhd with brcmfmac from backports-3.19-rc1

### DIFF
--- a/packages/linux-drivers/backports/package.mk
+++ b/packages/linux-drivers/backports/package.mk
@@ -1,0 +1,40 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="backports"
+PKG_VERSION="3.19-rc1"
+PKG_URL="http://www.kernel.org/pub/linux/kernel/projects/${PKG_NAME}/stable/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}-1.tar.xz"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.kernel.org"
+PKG_DEPENDS_HOST="ccache:host"
+PKG_DEPENDS_TARGET="toolchain xz:host linux"
+PKG_DEPENDS_INIT="toolchain"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_PRIORITY="optional"
+PKG_SECTION="virtual"
+PKG_SHORTDESC="backports: The linux driver backports for older kernels"
+PKG_LONGDESC="Backports provide drivers released on newer kernels backported for usage on older kernels."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+post_unpack() {
+  mv ${BUILD}/${PKG_NAME}-${PKG_VERSION}-1 ${BUILD}/${PKG_NAME}-${PKG_VERSION}
+}

--- a/packages/linux-drivers/brcmfmac/package.mk
+++ b/packages/linux-drivers/brcmfmac/package.mk
@@ -1,0 +1,55 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="brcmfmac"
+PKG_VERSION="3.19-rc1"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="various"
+PKG_SITE="https://wireless.wiki.kernel.org/en/users/Drivers/brcm80211"
+PKG_URL=""
+PKG_DEPENDS_TARGET="backports"
+PKG_PRIORITY="optional"
+PKG_SECTION="linux-drivers"
+PKG_SHORTDESC="brcmfmac: FullMAC driver for Broadcom WiFi chips"
+PKG_LONGDESC="brcmfmac: FullMAC driver for Broadcom WiFi chips"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+make_target() {
+  unset CC CFLAGS CXXFLAGS LDFLAGS MAKEFLAGS
+
+  cd ../backports-*
+
+  make clean defconfig-${PKG_NAME} modules V=1 \
+       ARCH=$TARGET_ARCH \
+       CROSS_COMPILE=$TARGET_PREFIX \
+       KLIB_BUILD=$(kernel_path) \
+       KLIB=$INSTALL/lib/modules/$(get_module_dir)
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME
+  cd ../backports-*
+  find . -name \*.ko -exec cp -f {} $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME \;
+}
+
+post_install() {
+  depmod -a -b $INSTALL $(get_module_dir)
+}

--- a/projects/Amlogic/devices/S859/filesystem/usr/lib/modules-load.d/brcmfmac.conf
+++ b/projects/Amlogic/devices/S859/filesystem/usr/lib/modules-load.d/brcmfmac.conf
@@ -1,0 +1,1 @@
+brcmfmac

--- a/projects/Amlogic/patches/backports/backports-0001-brcmfmac-Enable-GPIO-power-on-of-WiFi-chip-on-SDIO-i.patch
+++ b/projects/Amlogic/patches/backports/backports-0001-brcmfmac-Enable-GPIO-power-on-of-WiFi-chip-on-SDIO-i.patch
@@ -1,0 +1,61 @@
+From 07fb6f30c95e0ae0040c3374fdba16980996a7dd Mon Sep 17 00:00:00 2001
+From: Steeve Morin <steeve.morin@gmail.com>
+Date: Tue, 10 Feb 2015 17:12:05 +0100
+Subject: [PATCH 1/2] [brcmfmac] Enable GPIO power on of WiFi chip on SDIO init
+
+Signed-off-by: Steeve Morin <steeve.morin@gmail.com>
+---
+ drivers/net/wireless/brcm80211/brcmfmac/bcmsdh.c | 25 ++++++++++++++++++++----
+ 1 file changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/brcm80211/brcmfmac/bcmsdh.c b/drivers/net/wireless/brcm80211/brcmfmac/bcmsdh.c
+index 3c06e93..0032e71 100644
+--- a/drivers/net/wireless/brcm80211/brcmfmac/bcmsdh.c
++++ b/drivers/net/wireless/brcm80211/brcmfmac/bcmsdh.c
+@@ -62,6 +62,10 @@ static int brcmf_sdiod_txglomsz = BRCMF_DEFAULT_TXGLOM_SIZE;
+ module_param_named(txglomsz, brcmf_sdiod_txglomsz, int, 0);
+ MODULE_PARM_DESC(txglomsz, "maximum tx packet chain size [SDIO]");
+ 
++extern int wifi_setup_dt();
++extern void extern_wifi_set_enable(int is_on);
++extern void sdio_reinit(void);
++
+ static irqreturn_t brcmf_sdiod_oob_irqhandler(int irq, void *dev_id)
+ {
+ 	struct brcmf_bus *bus_if = dev_get_drvdata(dev_id);
+@@ -1068,10 +1072,10 @@ static int brcmf_ops_sdio_probe(struct sdio_func *func,
+ 	/* wowl can be supported when KEEP_POWER is true and (WAKE_SDIO_IRQ
+ 	 * is true or when platform data OOB irq is true).
+ 	 */
+-	if ((sdio_get_host_pm_caps(sdiodev->func[1]) & MMC_PM_KEEP_POWER) &&
+-	    ((sdio_get_host_pm_caps(sdiodev->func[1]) & MMC_PM_WAKE_SDIO_IRQ) ||
+-	     (sdiodev->pdata->oob_irq_supported)))
+-		bus_if->wowl_supported = true;
++	// if ((sdio_get_host_pm_caps(sdiodev->func[1]) & MMC_PM_KEEP_POWER) &&
++	//     ((sdio_get_host_pm_caps(sdiodev->func[1]) & MMC_PM_WAKE_SDIO_IRQ) ||
++	//      (sdiodev->pdata->oob_irq_supported)))
++	// 	bus_if->wowl_supported = true;
+ #endif
+ 
+ 	atomic_set(&sdiodev->suspend, false);
+@@ -1252,4 +1256,17 @@ void __init brcmf_sdio_init(void)
+ 	ret = platform_driver_probe(&brcmf_sdio_pd, brcmf_sdio_pd_probe);
+ 	if (ret == -ENODEV)
+ 		brcmf_dbg(SDIO, "No platform data available.\n");
++
++	printk(KERN_INFO "[meson-wifi] Setting up wifi device tree\n");
++	if (wifi_setup_dt()) {
++		printk("[meson-wifi] wifi_dt: fail to setup dt\n");
++	}
++	printk(KERN_INFO "[meson-wifi] Wifi power up via GPIO\n");
++	extern_wifi_set_enable(0);
++	mdelay(200);
++	extern_wifi_set_enable(1);
++	printk(KERN_INFO "[meson-wifi] Done wifi power up, reinit SDIO\n");
++	mdelay(200);
++	sdio_reinit();
++	printk(KERN_INFO "[meson-wifi] Wifi setup done\n");
+ }
+-- 
+2.2.1
+

--- a/projects/Amlogic/patches/linux/linux-300-Properly-set-max_blk_count-and-max_blk_size-for-the-.patch
+++ b/projects/Amlogic/patches/linux/linux-300-Properly-set-max_blk_count-and-max_blk_size-for-the-.patch
@@ -1,0 +1,31 @@
+From 6c92e578748e039dfcfd8e737efdead6cd3e7568 Mon Sep 17 00:00:00 2001
+From: Steeve Morin <steeve.morin@gmail.com>
+Date: Mon, 9 Feb 2015 16:25:49 +0100
+Subject: [PATCH 4/4] Properly set max_blk_count and max_blk_size for the host
+ mmc
+
+Signed-off-by: Steeve Morin <steeve.morin@gmail.com>
+---
+ drivers/amlogic/mmc/aml_sdio.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/amlogic/mmc/aml_sdio.c b/drivers/amlogic/mmc/aml_sdio.c
+index 680b95a..8b42f0e 100755
+--- a/drivers/amlogic/mmc/aml_sdio.c
++++ b/drivers/amlogic/mmc/aml_sdio.c
+@@ -1322,10 +1322,10 @@ static int aml_sdio_probe(struct platform_device *pdev)
+         mmc->alldev_claim = &aml_sdio_claim;
+         mmc->ios.clock = 400000;
+         mmc->ios.bus_width = MMC_BUS_WIDTH_1;
+-        mmc->max_blk_count = 4095;
+-        mmc->max_blk_size = 4095;
++        mmc->max_blk_count = 256;
+         mmc->max_req_size = pdata->max_req_size;
+         mmc->max_seg_size = mmc->max_req_size;
++        mmc->max_blk_size = mmc->max_req_size / mmc->max_blk_count;
+         mmc->max_segs = 1024;
+         mmc->ocr_avail = pdata->ocr_avail;
+         mmc->ocr = pdata->ocr_avail;
+-- 
+2.2.1
+


### PR DESCRIPTION
**This PR is not intended to be used lightly**

bcmdhd (the current wifi driver from Broadcom) is outdated and not in mainline.

This PR is a way for us to have newer, mainline, drivers. It uses linux backports to run that new driver onto linux-amlogic 3.10. The immediate gain is more stability, a more performance and get closer to mainline.

There is a twist though, at boost the wifi chip is off, so I needed to patch brcmfmac to enable it and rescan the SDIO bus. The DTD might be patched too, but I'm not so sure about that. I can add examples about this.

Finally, the driver needs to be loaded at boot via `modules.d`, because it does power up the wifi, hence no auto load by the kernel (it would if the wifi was on, though, perhaps via a fixed-regulator on the dtd?).

Firmwares and nvram files are not compatible, but since the Amlogic projects pull `wlan-firmware` as dependencies, we are good to go. For nvrams, however, this is another story. I might amend this PR to add nvrams for devices, if needed.

Note that I have opened a PR for 538c85aa1d6ee4151fa47a44e119b2c603f88268 at https://github.com/codesnake/linux-amlogic/pull/16, but I put it there in the mean time.

Lastly, to enable this driver, you need to disable `cfg80211` in the device's kernel and Amlogic's bcmdhd, but **not** Amlogic WiFi.
Then add in the `options` file:
```
ADDITIONAL_DRIVERS="brcmfmac"
```